### PR TITLE
Update workflow to run on updates to main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,9 @@
 name: Build and Deploy Decal Web
 
 on:
-  workflow_dispatch:
-  pull_request:
   push:
     branches:
-      - "*"
+      - "main"
 
 jobs:
 


### PR DESCRIPTION
Restricts workflow to only run when main branch is updated (and not on forks/any other branch).